### PR TITLE
add LICENSE.md to distributed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "index.js",
     "lib/mappingTable.json",
-    "lib/regexes.js"
+    "lib/regexes.js",
+    "LICENSE.md"
   ],
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
Hi Sebastian,

unfortunately MIT license requires the License text to be part even of the distributed package published to npm registry, I've modified the `package.json` to do that.
Thanks for merging and then releasing a new version. Would help open-source tremendously.